### PR TITLE
proof of concept for graceful timeouts

### DIFF
--- a/lib/standalone-tests/terminus.onshutdown.sigint.js
+++ b/lib/standalone-tests/terminus.onshutdown.sigint.js
@@ -1,11 +1,18 @@
 'use strict'
 const http = require('http')
-const server = http.createServer((req, res) => res.end('hello'))
+const server = http.createServer(
+  (req, res) => {
+    setTimeout(() => {
+      console.log('timeout expired')
+      res.end('hello')
+    }, 5000)
+  })
 
 const { createTerminus } = require('../../')
 const SIGNAL = 'SIGINT'
 
 createTerminus(server, {
+  timeout: 30000,
   signal: SIGNAL,
   onSignal: () => {
     console.log('on-sigint-runs')
@@ -17,5 +24,14 @@ createTerminus(server, {
 })
 
 server.listen(8000, () => {
-  process.kill(process.pid, SIGNAL)
+  http.get({
+    hostname: 'localhost',
+    port: 8000,
+    path: '/'
+  }, (res) => {
+    console.log('got a response!')
+  })
+  setTimeout(() => {
+    process.kill(process.pid, SIGNAL)
+  }, 1500)
 })

--- a/lib/standalone-tests/terminus.onshutdown.sigterm.js
+++ b/lib/standalone-tests/terminus.onshutdown.sigterm.js
@@ -1,10 +1,17 @@
 'use strict'
 const http = require('http')
-const server = http.createServer((req, res) => res.end('hello'))
+const server = http.createServer(
+  (req, res) => {
+    setTimeout(() => {
+      console.log('timeout expired')
+      res.end('hello')
+    }, 5000)
+  })
 
 const { createTerminus } = require('../../')
 
 createTerminus(server, {
+  timeout: 30000,
   onSignal: () => {
     console.log('on-sigterm-runs')
     return Promise.resolve()
@@ -15,5 +22,14 @@ createTerminus(server, {
 })
 
 server.listen(8000, () => {
-  process.kill(process.pid, 'SIGTERM')
+  http.get({
+    hostname: 'localhost',
+    port: 8000,
+    path: '/'
+  }, (res) => {
+    console.log('got a response!')
+  })
+  setTimeout(() => {
+    process.kill(process.pid, SIGNAL)
+  }, 1500)
 })

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -108,7 +108,7 @@ describe('Terminus', () => {
       let hasUnhandledRejection = false
 
       process.once('unhandledRejection', () => {
-        hasUnhandledRejection = true;
+        hasUnhandledRejection = true
       })
 
       server.on('request', () => {
@@ -121,7 +121,7 @@ describe('Terminus', () => {
             healthCheckRanTimes++
             return Promise.resolve()
           }
-        },
+        }
       })
       server.listen(8000)
 


### PR DESCRIPTION
Update spec to verify that graceful timeout is respected when stopping server. Logging output confirms the sequence of events matches what the lib is supposed to be doing, ie pending connection should be finished before 

```
> node lib/standalone-tests/terminus.onshutdown.sigint.js
timeout expired
got a response!
on-sigint-runs
on-shutdown-runs
```